### PR TITLE
Fix redirect to project page

### DIFF
--- a/server.js
+++ b/server.js
@@ -173,7 +173,7 @@ function generatePageHtml(project, projectId) {
     description,
     shareImageUrl,
     projectUrl,
-    `/projects/${projectId}`
+    `/project/${projectId}`
   );
 }
 


### PR DESCRIPTION
Update prerender redirect path from `/projects/` to `/project/` to match the correct URL structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c2c6342-2b17-4347-b1e9-f6de7fd9136e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c2c6342-2b17-4347-b1e9-f6de7fd9136e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

