### PR TITLE
Add portfolio.fcc.lol to CORS allowed origins

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,6 +26,8 @@ const corsOptions = {
     "http://localhost:8080",
     "https://fcc.lol",
     "https://www.fcc.lol",
+    "https://portfolio.fcc.lol",
+    "https://www.portfolio.fcc.lol",
     "https://rolodex-os.fcc.lol",
     "https://www.rolodex-os.fcc.lol"
   ],


### PR DESCRIPTION
## Summary
Added two new domains to the CORS allowed origins list to enable cross-origin requests from the portfolio subdomain.

## Changes
- Added `https://portfolio.fcc.lol` to corsOptions origins
- Added `https://www.portfolio.fcc.lol` to corsOptions origins

## Details
These domains follow the existing pattern of supporting both the base domain and www-prefixed variant, consistent with other allowed origins like `fcc.lol` and `rolodex-os.fcc.lol`.

https://claude.ai/code/session_01LXk7HKYgJyH6REW4nEBCtp