### PR TITLE
Add search_projects tool + self-correcting list_projects hint

### DIFF
--- a/server.js
+++ b/server.js
@@ -2389,12 +2389,97 @@ function createMcpServer() {
       }
     },
     async ({ tag, person } = {}) => {
-      let projects = await ensureProjects();
+      const all = await ensureProjects();
+      let projects = all;
       if (tag) projects = filterProjectsByTag(projects, tag);
       if (person) projects = filterProjectsByPerson(projects, person);
-      const sorted = sortProjectsByDate(projects);
       updateCacheInBackground();
-      return jsonResult(sorted.map(summarizeProject));
+
+      // When a filter matches nothing, return a hint instead of a bare [] so
+      // callers (e.g. LLMs) can self-correct — the most common mistake is
+      // passing a project *name* as a tag, which never matches.
+      if (projects.length === 0 && (tag || person)) {
+        return jsonResult({
+          results: [],
+          message:
+            "No projects matched. `tag` and `person` are exact filters, not a " +
+            "name search. To find a project by name or keyword, use " +
+            "search_projects instead.",
+          ...(tag ? { availableTags: getAllTags(all) } : {})
+        });
+      }
+
+      return jsonResult(sortProjectsByDate(projects).map(summarizeProject));
+    }
+  );
+
+  server.registerTool(
+    "search_projects",
+    {
+      title: "Search projects",
+      description:
+        "Search FCC Studio projects by free-text terms, tags, and/or year. Query syntax (space-separated): plain words match the title, description, tags, and credited people; #tag filters by an exact tag (all #tags required); a year like 2025 or a range like 2023-2025 filters by date. Empty query returns every project, newest first. Use this (not list_projects) to find a project by name.",
+      inputSchema: {
+        query: z
+          .string()
+          .optional()
+          .default("")
+          .describe(
+            'Search query, e.g. "cyberdeck" or "robot #hardware 2024-2025". Empty string returns all projects.'
+          )
+      }
+    },
+    async ({ query = "" } = {}) => {
+      let projects = await ensureProjects();
+
+      const tags = [];
+      const words = [];
+      let yearFrom = null;
+      let yearTo = null;
+
+      for (const tok of query.trim().split(/\s+/).filter(Boolean)) {
+        if (tok.startsWith("#") && tok.length > 1) {
+          tags.push(tok.slice(1));
+        } else if (/^\d{4}$/.test(tok)) {
+          yearFrom = yearTo = Number(tok);
+        } else if (/^\d{4}-\d{4}$/.test(tok)) {
+          const [a, b] = tok.split("-").map(Number);
+          yearFrom = Math.min(a, b);
+          yearTo = Math.max(a, b);
+        } else {
+          words.push(tok.toLowerCase());
+        }
+      }
+
+      for (const tag of tags) {
+        projects = filterProjectsByTag(projects, tag);
+      }
+
+      if (yearFrom !== null) {
+        projects = projects.filter((project) => {
+          const year = Number(String(project.date || "").slice(0, 4));
+          return year >= yearFrom && year <= yearTo;
+        });
+      }
+
+      if (words.length) {
+        projects = projects.filter((project) => {
+          const haystack = [
+            project.title,
+            project.name,
+            project.description,
+            ...(project.tags || []),
+            ...(project.credits || []).map((credit) => credit?.name || credit)
+          ]
+            .filter(Boolean)
+            .join(" ")
+            .toLowerCase();
+          return words.every((word) => haystack.includes(word));
+        });
+      }
+
+      updateCacheInBackground();
+      return jsonResult(sortProjectsByDate(projects).map(summarizeProject));
     }
   );
 


### PR DESCRIPTION
## Why

The API has no free-text / by-name project search. The only discovery tool is `list_projects`, which filters by **exact `tag`** or **`person`**. So a caller that knows a project *name* (e.g. an LLM asked "what's the Cyberdeck 25 project?") has no correct slot for it — it passes the name as `tag`, `filterProjectsByTag` finds no such tag, and the tool returns a bare `[]`. The caller can't tell whether the project doesn't exist or it just used the wrong filter, so it gives up.

For comparison, the `leomancini.net/mcp` server exposes a single forgiving `search_projects(query)` and "just works" on the first try. This PR brings the same ergonomics to portfolio-api.

## What

**1. New `search_projects` tool** — mirrors the leomancini server's query syntax so both behave identically:
- plain words → match title / description / tags / credited people (all words required)
- `#tag` → exact tag filter (all `#tags` required)
- `2025` or `2023-2025` → filter by project date
- empty query → all projects, newest first

Reuses existing helpers (`ensureProjects`, `filterProjectsByTag`, `sortProjectsByDate`, `summarizeProject`, `jsonResult`); no new dependencies.

**2. `list_projects` returns a hint instead of `[]`** when a `tag`/`person` filter matches nothing — explains that those are exact filters (not a name search), points to `search_projects`, and includes `availableTags` when a `tag` was given. Non-empty and unfiltered results are unchanged.

## Testing
- `node --check server.js` passes.
- Verified against live data: `search_projects` query `cyberdeck 25` matches the project by title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)